### PR TITLE
Feat/multiple-file-context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,17 @@
 {
     "terminal.integrated.env.osx": {
-      "PYTHONPATH": "${workspaceFolder}/src",
+      "PYTHONPATH": "${workspaceFolder}/src; ${workspaceFolder}",
     },
     "terminal.integrated.env.linux": {
-      "PYTHONPATH": "${workspaceFolder}/src",
+      "PYTHONPATH": "${workspaceFolder}/src; ${workspaceFolder}",
     },
     "terminal.integrated.env.windows": {
-      "PYTHONPATH": "${workspaceFolder}/src",
+      "PYTHONPATH": "${workspaceFolder}/src; ${workspaceFolder}",
     },
-    "python.envFile": "${workspaceFolder}/.env"
+    "python.envFile": "${workspaceFolder}/.env",
+    "python.testing.pytestArgs": [
+      "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/src/codeas/_templates.py
+++ b/src/codeas/_templates.py
@@ -11,3 +11,35 @@ INSTRUCTIONS:
 
 IMPORTANT: only return the {target}. Do not include explanations outside of the {target}.
 """
+
+TEMPLATE_GLOBAL = """
+You are a senior software developer.
+You will be given files containing code and instructions to perform on these files.
+
+The files will be given to you in xml format, the markup tags will be the file name and the text between the tags the content of the file.
+You should use the same format to return the modified files.
+
+Example:
+
+<FILE_NAME>
+def function():
+    pass
+</FILE_NAME>
+
+INSTRUCTIONS:
+Generate docstrings
+
+Your answer:
+
+<FILE_NAME>
+def function():
+    '''Docstrings you have generated'''
+    pass
+</FILE_NAME>
+
+{global_context}
+
+INSTRUCTIONS:
+{instructions}
+{guideline_prompt}
+"""

--- a/src/codeas/_templates.py
+++ b/src/codeas/_templates.py
@@ -19,7 +19,7 @@ You will be given files containing code and instructions to perform on these fil
 The files will be given to you in xml format, the markup tags will be the file name and the text between the tags the content of the file.
 You should use the same format to return the modified files.
 
-Example:
+Example request:
 
 <FILE_NAME>
 def function():
@@ -29,7 +29,7 @@ def function():
 INSTRUCTIONS:
 Generate docstrings
 
-Your answer:
+Example answer:
 
 <FILE_NAME>
 def function():
@@ -37,9 +37,12 @@ def function():
     pass
 </FILE_NAME>
 
+Request:
 {global_context}
 
 INSTRUCTIONS:
 {instructions}
 {guideline_prompt}
+
+Answer:
 """

--- a/src/codeas/codebase.py
+++ b/src/codeas/codebase.py
@@ -90,11 +90,7 @@ class Codebase(BaseModel):
             module_content = source.read()
         node = self._parser.parse(bytes(module_content, "utf8")).root_node
         rel_path = os.path.relpath(path, self.code_folder)
-        name = (
-            os.path.splitext(rel_path)[0]
-            .replace(os.path.sep, ".")
-            .strip(self.code_format)
-        )
+        name = os.path.splitext(rel_path)[0].replace(os.path.sep, ".")
         module = Module(name=name, node=node, parser=self._parser)
         module.parse_entities()
         self._modules.append(module)

--- a/src/codeas/file_handler.py
+++ b/src/codeas/file_handler.py
@@ -93,7 +93,7 @@ class FileHandler(BaseModel):
 
     def make_backup_dir(self):
         if not os.path.exists(self.backup_dir):
-            os.mkdir(self.backup_dir)
+            os.makedirs(self.backup_dir)
 
     def move_target_files_to_backup(self):
         for target_path in self._target_files:

--- a/src/codeas/request.py
+++ b/src/codeas/request.py
@@ -33,13 +33,13 @@ class Request(BaseModel):
     target: str
 
     def execute_globally(
-        self, codebase: Codebase, modules: List[str], verbose: bool = True
+        self, codebase: Codebase, modules: List[str] = None, verbose: bool = True
     ):
         logging.info("Executing request globally")
 
         global_context = ""
         for module in codebase.get_modules(modules):
-            global_context += f"<{module.name}>"
+            global_context += f"\n<{module.name}>\n"
             global_context += module.get(self.context)
             global_context += f"</{module.name}>\n"
 
@@ -58,7 +58,7 @@ class Request(BaseModel):
             module = codebase.get_module(module_name)
             module.modify(self.target, module_content)
 
-    def _parse_markup_string(input_string):
+    def _parse_markup_string(self, input_string):
         pattern = r"<([^<>]+)>\n(.*?)\n</\1>"
         matches = re.findall(pattern, input_string, re.DOTALL)
         return [(match[0], match[1]) for match in matches]

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -21,7 +21,7 @@ def assistant():
     return Assistant()
 
 
-def test_init_configs(assistant):
+def test_init_configs(assistant: Assistant):
     if os.path.exists(".codeas"):
         shutil.rmtree("./.codeas")
     assistant.init_configs()
@@ -30,24 +30,25 @@ def test_init_configs(assistant):
     assert os.path.exists(".codeas/prompts.yaml")
 
 
-def test_execute_preprompt(assistant):
+def test_execute_preprompt(assistant: Assistant):
     _monkeypatch_prompts(assistant)
     _monkeypatch_model(assistant)
     assistant.execute_preprompt("modify_code")
     assert os.path.exists("./src/module1_preview.py")
 
 
-def _monkeypatch_prompts(assistant):
+def _monkeypatch_prompts(assistant: Assistant):
     assistant._prompts = {
         "modify_code": {
             "instructions": "modify some code",
             "target": "code",
             "context": "code",
+            "scope": "module",
         }
     }
 
 
-def _monkeypatch_model(assistant):
+def _monkeypatch_model(assistant: Assistant):
     assistant.model = "fake"
     assistant._set_openai_model()
 
@@ -60,12 +61,10 @@ def _monkeypatch_model(assistant):
         ("docs", "code"),
     ],
 )
-def test_execute_prompt(target, context, assistant):
+def test_execute_prompt(target, context, assistant: Assistant):
     _monkeypatch_model(assistant)
     assistant.execute_prompt(
-        instructions="instructions",
-        target=target,
-        context=context,
+        instructions="instructions", target=target, context=context, scope="module"
     )
     if target == "code":
         assert os.path.exists("./src/module1_preview.py")
@@ -75,19 +74,19 @@ def test_execute_prompt(target, context, assistant):
         assert os.path.exists("./docs/module1_preview.md")
 
 
-def test_apply_changes(assistant):
+def test_apply_changes(assistant: Assistant):
     _monkeypatch_model(assistant)
-    assistant.execute_prompt("instructions")
+    assistant.execute_prompt("instructions", scope="module")
     assistant.apply_changes()
     assert not os.path.exists("./src/module1_preview.py")
     assert os.path.exists("./.codeas/backup/module1.py")
 
 
-def test_reject_changes(assistant):
+def test_reject_changes(assistant: Assistant):
     if os.path.exists("./.codeas/backup/"):
         shutil.rmtree("./.codeas/backup/")
     _monkeypatch_model(assistant)
-    assistant.execute_prompt("instructions")
+    assistant.execute_prompt("instructions", scope="module")
     assistant.reject_changes()
     assert not os.path.exists("./src/module1_preview.py")
     assert not os.path.exists("./.codeas/backup/module1.py")

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -6,31 +6,19 @@ from dotenv import load_dotenv
 
 from codeas.assistant import Assistant
 
+from .utils import create_dummy_repo, remove_dummy_repo, reset_dummy_repo
+
 load_dotenv()
 
-os.chdir("./tests")
+remove_dummy_repo()
+create_dummy_repo()
+os.chdir("./dummy_repo")
 
 
 @pytest.fixture
 def assistant():
-    _clean_dummy_files()
-    _create_dummy_files()
+    reset_dummy_repo()
     return Assistant()
-
-
-def _clean_dummy_files():
-    if os.path.exists("./src"):
-        shutil.rmtree("./src")
-    if os.path.exists("./tests"):
-        shutil.rmtree("./tests")
-    if os.path.exists("./docs"):
-        shutil.rmtree("./docs")
-
-
-def _create_dummy_files():
-    os.mkdir("./src")
-    with open("./src/dummy_module.py", "w") as f:
-        f.write("def dummy_function():\n    pass\n")
 
 
 def test_init_configs(assistant):
@@ -106,6 +94,5 @@ def test_reject_changes(assistant):
 
 
 def test_cleanup():
-    _clean_dummy_files()
-    if os.path.exists(".codeas"):
-        shutil.rmtree("./.codeas")
+    os.chdir("..")
+    remove_dummy_repo()

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -34,7 +34,7 @@ def test_execute_preprompt(assistant):
     _monkeypatch_prompts(assistant)
     _monkeypatch_model(assistant)
     assistant.execute_preprompt("modify_code")
-    assert os.path.exists("./src/dummy_module_preview.py")
+    assert os.path.exists("./src/module1_preview.py")
 
 
 def _monkeypatch_prompts(assistant):
@@ -68,19 +68,19 @@ def test_execute_prompt(target, context, assistant):
         context=context,
     )
     if target == "code":
-        assert os.path.exists("./src/dummy_module_preview.py")
+        assert os.path.exists("./src/module1_preview.py")
     elif target == "tests":
-        assert os.path.exists("./tests/test_dummy_module_preview.py")
+        assert os.path.exists("./tests/test_module1_preview.py")
     elif target == "docs":
-        assert os.path.exists("./docs/dummy_module_preview.md")
+        assert os.path.exists("./docs/module1_preview.md")
 
 
 def test_apply_changes(assistant):
     _monkeypatch_model(assistant)
     assistant.execute_prompt("instructions")
     assistant.apply_changes()
-    assert not os.path.exists("./src/dummy_module_preview.py")
-    assert os.path.exists("./.codeas/backup/dummy_module.py")
+    assert not os.path.exists("./src/module1_preview.py")
+    assert os.path.exists("./.codeas/backup/module1.py")
 
 
 def test_reject_changes(assistant):
@@ -89,8 +89,8 @@ def test_reject_changes(assistant):
     _monkeypatch_model(assistant)
     assistant.execute_prompt("instructions")
     assistant.reject_changes()
-    assert not os.path.exists("./src/dummy_module_preview.py")
-    assert not os.path.exists("./.codeas/backup/dummy_module.py")
+    assert not os.path.exists("./src/module1_preview.py")
+    assert not os.path.exists("./.codeas/backup/module1.py")
 
 
 def test_cleanup():

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -21,10 +21,6 @@ msg = AIMessage(
     content=f"<module1>\n{dummy_func1}\n</module1>\n\n<module2>\n{dummy_func2}\n</module2>\n\n"
 )
 model = FakeMessagesListChatModel(responses=[msg])
-# model = ChatOpenAI(
-#     callbacks=[StreamingStdOutCallbackHandler()],
-#     streaming=True,
-# )
 
 codebase = Codebase(language="python")
 codebase.parse_modules()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,47 @@
+import os
+
+from dotenv import load_dotenv
+from langchain.chat_models.fake import FakeMessagesListChatModel
+from langchain.schema import AIMessage
+
+from codeas.codebase import Codebase
+from codeas.request import Request
+
+from .utils import create_dummy_repo, remove_dummy_repo
+
+load_dotenv()
+
+remove_dummy_repo()
+create_dummy_repo()
+os.chdir("./dummy_repo")
+
+dummy_func1 = """def dummy_func_rewritten1():\n    print('it worked')"""
+dummy_func2 = """def dummy_func_rewritten12():\n    print('it worked')"""
+msg = AIMessage(
+    content=f"<module1>\n{dummy_func1}\n</module1>\n\n<module2>\n{dummy_func2}\n</module2>\n\n"
+)
+model = FakeMessagesListChatModel(responses=[msg])
+# model = ChatOpenAI(
+#     callbacks=[StreamingStdOutCallbackHandler()],
+#     streaming=True,
+# )
+
+codebase = Codebase(language="python")
+codebase.parse_modules()
+
+
+def test_execute_globally():
+    request = Request(
+        instructions="instructions",
+        model=model,
+        context="code",
+        target="code",
+        guideline_prompt="",
+    )
+    request.execute_globally(codebase)
+    assert codebase.get_module("module1").code == dummy_func1
+
+
+def test_cleanup():
+    os.chdir("..")
+    remove_dummy_repo()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+
+
+def create_dummy_repo():
+    os.makedirs("./dummy_repo/src")
+    with open("./dummy_repo/src/module1.py", "w") as f:
+        f.write("def dummy_function1():\n    pass\n")
+    with open("./dummy_repo/src/module2.py", "w") as f:
+        f.write("def dummy_function2():\n    pass\n")
+
+
+def remove_dummy_repo():
+    if os.path.exists("./dummy_repo"):
+        shutil.rmtree("./dummy_repo")
+
+
+def reset_dummy_repo():
+    os.chdir("..")
+    remove_dummy_repo()
+    create_dummy_repo()
+    os.chdir("./dummy_repo")


### PR DESCRIPTION
Make it possible to pass multiple modules at once as context, instead of passing module by module. 

This is handled by the parameter "scope" = "Module" or "Global" inside of the Assistant.run_prompt() method