### PR TITLE
build: add virtualenv support to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.venv/
 *__pycache__/
 debug/
 .backup/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VENV := .venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 
-.PHONY: venv
+.PHONY: venv install run pre-commit style help
 venv: ## Crea el virtualenv del proyecto
 	@if [ ! -d "$(VENV)" ]; then \
 		echo "Creating virtualenv..." && \

--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,20 @@ install: venv ## Instala las dependencias del proyecto
 	@echo "Installing dependencies..." && \
 	$(PIP) install -e .
 
+install-dev: venv ## Instala las dependencias de desarrollo (pre-commit, black, isort, ruff)
+	@echo "Installing development tools..." && \
+	$(PIP) install pre-commit black isort ruff
+
 run: install ## Inicia la aplicación Codeas (instala dependencias primero)
 	@echo "Starting Codeas..." && \
 	$(PYTHON) -m streamlit run src/codeas/ui/🏠_Home.py
 
-pre-commit: venv ## Instala y configura pre-commit hooks
-	@echo "Installing pre-commit..." && \
-	$(PIP) install pre-commit && \
+pre-commit: install-dev ## Instala y configura pre-commit hooks
+	@echo "Configuring pre-commit hooks..." && \
 	$(VENV)/bin/pre-commit install
 
-style: venv ## Formatea el código con black, isort y ruff
-	@echo "Installing style tools..." && \
-	$(PIP) install black isort ruff && \
+style: install-dev ## Formatea el código con black, isort y ruff
+	@echo "Running style tools..." && \
 	echo "Run black" && \
 	$(VENV)/bin/black . && \
 	echo "Run isort" && \

--- a/Makefile
+++ b/Makefile
@@ -4,32 +4,34 @@ VENV := .venv
 PYTHON := $(VENV)/bin/python
 PIP := $(VENV)/bin/pip
 
-.PHONY: venv install run pre-commit style help
-venv: ## Crea el virtualenv del proyecto
+.PHONY: venv
+venv: ## Create project virtualenv
 	@if [ ! -d "$(VENV)" ]; then \
 		echo "Creating virtualenv..." && \
 		python3 -m venv $(VENV) && \
 		$(PIP) install --upgrade pip; \
 	fi
 
-install: venv ## Instala las dependencias del proyecto
+install: venv ## Install project dependencies
 	@echo "Installing dependencies..." && \
 	$(PIP) install -e .
 
-install-dev: venv ## Instala las dependencias de desarrollo (pre-commit, black, isort, ruff)
+install-dev: venv ## Installs development tools
 	@echo "Installing development tools..." && \
 	$(PIP) install pre-commit black isort ruff
 
-run: install ## Inicia la aplicación Codeas (instala dependencias primero)
+run: install ## Start Codeas application (installs dependencies first)
 	@echo "Starting Codeas..." && \
 	$(PYTHON) -m streamlit run src/codeas/ui/🏠_Home.py
 
-pre-commit: install-dev ## Instala y configura pre-commit hooks
-	@echo "Configuring pre-commit hooks..." && \
+pre-commit: install-dev ## Installs and configures pre-commit hooks
+	@echo "Installing pre-commit..." && \
+	$(PIP) install pre-commit && \
 	$(VENV)/bin/pre-commit install
 
-style: install-dev ## Formatea el código con black, isort y ruff
-	@echo "Running style tools..." && \
+style: venv ## Formats code with black, isort, and ruff
+	@echo "Installing style tools..." && \
+	$(PIP) install black isort ruff && \
 	echo "Run black" && \
 	$(VENV)/bin/black . && \
 	echo "Run isort" && \
@@ -37,7 +39,7 @@ style: install-dev ## Formatea el código con black, isort y ruff
 	echo "Run ruff" && \
 	$(VENV)/bin/ruff check . --fix
 
-help: ## Muestra esta ayuda
-	@echo "Uso: make [target]\n"
-	@echo "Targets disponibles:"
+help: ## Show this help
+	@echo "Usage: make [target]\n"
+	@echo "Available targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ pre-commit: install-dev ## Installs and configures pre-commit hooks
 style: venv ## Formats code with black, isort, and ruff
 	@echo "Installing style tools..." && \
 	$(PIP) install black isort ruff && \
-	echo "Run black" && \
+	@echo "Run black" && \
 	$(VENV)/bin/black . && \
-	echo "Run isort" && \
+	@echo "Run isort" && \
 	$(VENV)/bin/isort . && \
-	echo "Run ruff" && \
+	@echo "Run ruff" && \
 	$(VENV)/bin/ruff check . --fix
 
 help: ## Show this help

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,37 @@
-style:
+.DEFAULT_GOAL := help
+
+VENV := .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
+
+.PHONY: venv
+venv: ## Crea el virtualenv del proyecto
+	@echo "Creating virtualenv..." && \
+	python3 -m venv $(VENV) && \
+	$(PIP) install --upgrade pip
+
+install: venv ## Instala las dependencias del proyecto
+	@echo "Installing dependencies..." && \
+	$(PIP) install -e .
+
+run: install ## Inicia la aplicación Codeas (instala dependencias primero)
+	@echo "Starting Codeas..." && \
+	$(PYTHON) -m streamlit run src/codeas/ui/🏠_Home.py
+
+pre-commit: venv ## Instala y configura pre-commit hooks
+	@echo "Installing pre-commit..." && \
+	$(PIP) install pre-commit && \
+	$(VENV)/bin/pre-commit install
+
+style: venv ## Formatea el código con black, isort y ruff
 	@echo "Run black" && \
-	black . && \
+	$(VENV)/bin/black . && \
 	echo "Run isort" && \
-	isort . && \
+	$(VENV)/bin/isort . && \
 	echo "Run ruff" && \
-	ruff . --fix
+	$(VENV)/bin/ruff check . --fix
+
+help: ## Muestra esta ayuda
+	@echo "Uso: make [target]\n"
+	@echo "Targets disponibles:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ PIP := $(VENV)/bin/pip
 
 .PHONY: venv
 venv: ## Crea el virtualenv del proyecto
-	@echo "Creating virtualenv..." && \
-	python3 -m venv $(VENV) && \
-	$(PIP) install --upgrade pip
+	@if [ ! -d "$(VENV)" ]; then \
+		echo "Creating virtualenv..." && \
+		python3 -m venv $(VENV) && \
+		$(PIP) install --upgrade pip; \
+	fi
 
 install: venv ## Instala las dependencias del proyecto
 	@echo "Installing dependencies..." && \
@@ -24,7 +26,9 @@ pre-commit: venv ## Instala y configura pre-commit hooks
 	$(VENV)/bin/pre-commit install
 
 style: venv ## Formatea el código con black, isort y ruff
-	@echo "Run black" && \
+	@echo "Installing style tools..." && \
+	$(PIP) install black isort ruff && \
+	echo "Run black" && \
 	$(VENV)/bin/black . && \
 	echo "Run isort" && \
 	$(VENV)/bin/isort . && \

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Codeas provides a user-friendly Streamlit interface to interact with your codeba
 codeas
 ```
 
+#### Development setup
+
+For development, you can use the Makefile which handles virtualenv creation and dependencies:
+
+```bash
+make run
+```
+
+This will create a virtual environment, install dependencies, and start the application.
+
 The Streamlit interface offers several features:
 
 1. **Documentation Generation**: Automatically generate comprehensive documentation for your project.


### PR DESCRIPTION
- Add venv target with .PHONY for virtualenv creation
- Update install, run, pre-commit and style targets to depend on venv
- Use virtualenv binaries for all Python tools
- Add help target with usage documentation
- Add .venv/ to .gitignore

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>